### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-code.rana.fun


### PR DESCRIPTION
Since code.rana.fun no longer exists, remove the CNAME, or update the URL.